### PR TITLE
v1.5.0-beta.3: Buy-Now-Flow, Etch-native Variation Swatches, Woo-CSS-Checkbox + Doku-Fixes (#1–#8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); ver
 
 Releases are published as [GitHub Releases](https://github.com/tobiashaas/woo4etch/releases); regular plugin installs self-update from there. The same changelog ships inside the plugin in `plugin/woo4etch/readme.txt` — keep both in sync.
 
+## [1.5.0-beta.3] — 2026-06-12
+
+Pre-release — not offered to installed sites via the auto-updater; install manually to test.
+
+### Added
+
+- **Buy-now flow built in:** a submit button `name="buy_now"` inside `form.cart` sends the customer straight to checkout after the normal, validated add-to-cart — no snippet needed. Filters: `woo4etch/enable_buy_now` (default on), `woo4etch/buy_now_empty_cart` (default off; opt in for true one-click checkout where the cart is emptied first). New template: `templates/16-one-click-checkout.md`.
+- **Variation swatches, Etch-native:** new bundled script (`assets/swatches.js`, enqueued on product pages) bridges clicks on your own Etch-built swatch markup (`data-w4e-swatch` / `data-attribute` / `data-value`) to the hidden native attribute `<select>`, so WooCommerce's variation logic (price, stock, `variation_id`) keeps working untouched. Selected state via `.is-selected` + `aria-pressed`; Woo's "Clear" link resets the swatches. Filter: `woo4etch/enqueue_swatches`. Documented in `templates/02-single-product-variable.md`.
+- **Settings section** (Etch → Woo4Etch): checkbox **Disable WooCommerce default styles** removes all three Woo stylesheets so Etch styles start from a blank slate — and brings them back when unchecked (no snippet hunt). Filter override: `woo4etch/disable_woo_styles`.
+
+### Documentation
+
+- New `templates/16-one-click-checkout.md` (Buy Now → checkout → thank-you, incl. guest checkout test checklist) and `templates/17-components.md` (Etch component blueprints with the pre-wired, do-not-touch Woo attributes).
+- `docs/ADR-001-no-template-overrides.md`: architecture decision — Woo4Etch never overrides WooCommerce PHP template files; strict layer separation (plugin logic auto-updates, user layouts are never touched).
+- Single product: the excerpt must be a **Raw HTML** element, not a Paragraph — Woo short descriptions may contain HTML (`templates/01-single-product-simple.md`).
+- Cart: snippet to remove the duplicate Gutenberg `wp-block-post-title` heading on Woo pages (`templates/04-cart.md`, `templates/functions-snippets.md`).
+- Etch context guide: new section on condition blocks hiding content in the builder, with workarounds (`templates/10-etch-context-and-templates.md`).
+
 ## [1.5.0-beta.2] — 2026-06-12
 
 Pre-release — not offered to installed sites via the auto-updater; install manually to test.
@@ -93,6 +111,7 @@ Pre-release — published on GitHub as a pre-release, so it is **not** offered t
 
 - Initial release with 17 shortcodes.
 
+[1.5.0-beta.3]: https://github.com/tobiashaas/woo4etch/releases/tag/v1.5.0-beta.3
 [1.5.0-beta.2]: https://github.com/tobiashaas/woo4etch/releases/tag/v1.5.0-beta.2
 [1.5.0-beta.1]: https://github.com/tobiashaas/woo4etch/releases/tag/v1.5.0-beta.1
 [1.4.1]: https://github.com/tobiashaas/woo4etch/releases/tag/v1.4.1

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Etch doesn't (yet) have native WooCommerce blocks. This repo documents what's ne
 | [`13-useful-snippets.md`](./templates/13-useful-snippets.md) | Curated practical snippets |
 | [`14-visual-hook-guides.md`](./templates/14-visual-hook-guides.md) | Business Bloomer hook diagrams |
 | [`15-woo4etch-plugin.md`](./templates/15-woo4etch-plugin.md) | Woo4Etch plugin (shortcodes + install) |
+| [`16-one-click-checkout.md`](./templates/16-one-click-checkout.md) | One-click checkout (Buy Now → checkout → thank-you) |
+| [`17-components.md`](./templates/17-components.md) | Component blueprints with pre-wired Woo markup |
 | [`functions-snippets.md`](./templates/functions-snippets.md) | Consolidated PHP snippets |
 | [`etch-copy/`](./templates/etch-copy/README.md) | Copy/paste Etch snippets — paste a ready-made layout (e.g. the full cart) into the builder |
 

--- a/docs/ADR-001-no-template-overrides.md
+++ b/docs/ADR-001-no-template-overrides.md
@@ -1,0 +1,36 @@
+# ADR-001 — No WooCommerce template overrides
+
+**Status:** Accepted · **Date:** 2026-06-12
+
+## Context
+
+Page builders like Bricks override WooCommerce's PHP template files (`woocommerce/cart/cart.php` etc.). Those copies go stale with every WooCommerce release, producing the well-known admin warning *"Your theme contains outdated copies of some WooCommerce template files"* and forcing the theme/builder author to re-sync templates on every release.
+
+At the same time, Woo4Etch users must be able to customise their layouts in Etch without limits — and without updates ever overwriting their work.
+
+## Decision
+
+**Woo4Etch never overrides WooCommerce PHP template files.** Everything is built on hooks, shortcodes, and the dynamic-data bridges, with a strict separation of layers:
+
+| Layer | Owner | Update behaviour |
+|---|---|---|
+| **PHP logic** (shortcodes, hooks, WC integration, dynamic-data bridges) | Woo4Etch plugin | Auto-updates via GitHub Releases — transparent to the user |
+| **Etch layout** (HTML structure, classes, design) | User | Belongs to the user; never changed automatically |
+| **Required Woo attributes** (`form.cart`, `name="add-to-cart"`, `name="quantity"`, `.single_add_to_cart_button`, …) | Documentation | The only contract between user markup and WC server logic; stable for 10+ years. Breaking changes (rare) are highlighted in the changelog and README |
+
+## Consequences
+
+**Positive**
+
+- No "outdated templates" warning; no template re-sync on WooCommerce releases.
+- Plugin updates (new shortcodes, fixes) reach users automatically without touching layouts.
+- User layouts in Etch are infinitely customisable and update-safe.
+- WooCommerce core logic (cart maths, checkout processing, stock, coupons) updates independently of the layout.
+
+**Trade-off**
+
+- Layout improvements in the documentation templates do not reach existing users automatically — markup changes are adopted deliberately by the user. That is intentional: the layout belongs to the user.
+
+## Related notes
+
+- The WooCommerce status-page warnings ("page does not contain the [woocommerce_cart] shortcode") are informational checks only. Cart/checkout logic runs server-side regardless; with correctly attributed Etch markup these warnings are safe to ignore.

--- a/plugin/woo4etch/assets/swatches.js
+++ b/plugin/woo4etch/assets/swatches.js
@@ -1,0 +1,80 @@
+/**
+ * Woo4Etch — variation swatch sync.
+ *
+ * The swatch markup is built entirely in Etch (loop over the attribute terms);
+ * this script only bridges clicks to the native attribute <select> inside
+ * form.variations_form, so WooCommerce's variation logic (price, stock,
+ * variation_id) keeps working untouched.
+ *
+ * Expected swatch markup (anything clickable):
+ *   <button type="button"
+ *           data-w4e-swatch
+ *           data-attribute="attribute_pa_color"
+ *           data-value="blue">…</button>
+ *
+ * The selected swatch gets the class `is-selected` (style it in Etch) and
+ * aria-pressed="true". Woo's "Clear" link resets all swatches.
+ */
+(function () {
+	'use strict';
+
+	function swatchesFor(attribute) {
+		return document.querySelectorAll('[data-w4e-swatch][data-attribute="' + attribute + '"]');
+	}
+
+	function markSelected(attribute, active) {
+		swatchesFor(attribute).forEach(function (el) {
+			var selected = el === active;
+			el.classList.toggle('is-selected', selected);
+			el.setAttribute('aria-pressed', selected ? 'true' : 'false');
+		});
+	}
+
+	function syncSelect(swatch) {
+		var attribute = swatch.getAttribute('data-attribute');
+		var value = swatch.getAttribute('data-value') || '';
+		if (!attribute) {
+			return;
+		}
+
+		var form = swatch.closest('form.variations_form') || document.querySelector('form.variations_form');
+		if (!form) {
+			return;
+		}
+
+		var select = form.querySelector('select[name="' + attribute + '"]');
+		if (!select) {
+			return;
+		}
+
+		select.value = value;
+
+		// Woo's variation JS listens through jQuery; fall back to a native event.
+		if (window.jQuery) {
+			window.jQuery(select).trigger('change');
+		} else {
+			select.dispatchEvent(new Event('change', { bubbles: true }));
+		}
+
+		markSelected(attribute, value === '' ? null : swatch);
+	}
+
+	document.addEventListener('click', function (event) {
+		var swatch = event.target.closest('[data-w4e-swatch]');
+		if (!swatch) {
+			return;
+		}
+		event.preventDefault();
+		syncSelect(swatch);
+	});
+
+	// Woo's "Clear" link fires reset_data on the form — unselect all swatches.
+	if (window.jQuery) {
+		window.jQuery(document).on('reset_data', 'form.variations_form', function () {
+			document.querySelectorAll('[data-w4e-swatch].is-selected').forEach(function (el) {
+				el.classList.remove('is-selected');
+				el.setAttribute('aria-pressed', 'false');
+			});
+		});
+	}
+})();

--- a/plugin/woo4etch/includes/class-woo4etch-admin.php
+++ b/plugin/woo4etch/includes/class-woo4etch-admin.php
@@ -23,6 +23,27 @@ final class Woo4Etch_Admin {
         add_action('admin_menu', [__CLASS__, 'register_menu'], 99);
         add_action('admin_enqueue_scripts', [__CLASS__, 'enqueue_assets']);
         add_action('admin_post_woo4etch_install_layout', [__CLASS__, 'handle_install_layout']);
+        add_action('admin_post_woo4etch_save_settings', [__CLASS__, 'handle_save_settings']);
+    }
+
+    /**
+     * admin-post handler: persist the plugin settings (currently the
+     * "disable WooCommerce styles" checkbox).
+     */
+    public static function handle_save_settings() {
+        if (!current_user_can(apply_filters('woo4etch/admin_capability', 'manage_woocommerce'))) {
+            wp_die(esc_html__('You do not have permission to do this.', 'woo4etch'));
+        }
+        check_admin_referer('woo4etch_save_settings');
+
+        $settings = (array) get_option('woo4etch_settings', []);
+        $settings['disable_woo_styles'] = !empty($_POST['disable_woo_styles']);
+        update_option('woo4etch_settings', $settings);
+
+        $redirect = wp_get_referer() ?: admin_url('admin.php?page=' . self::PAGE_SLUG);
+        $redirect = add_query_arg('w4e_settings_saved', '1', remove_query_arg('w4e_settings_saved', $redirect));
+        wp_safe_redirect($redirect);
+        exit;
     }
 
     /**
@@ -144,6 +165,44 @@ final class Woo4Etch_Admin {
             . '.woo4etch-shortcodes .woo4etch-intro{max-width:72em;}'
             . '.woo4etch-shortcodes .woo4etch-installed{color:#00a32a;font-weight:700;margin-left:4px;}'
         );
+    }
+
+    /**
+     * Settings: toggles that would otherwise need a PHP snippet.
+     */
+    private static function render_settings_section() {
+        // phpcs:disable WordPress.Security.NonceVerification.Recommended -- read-only notice flag.
+        $saved = isset($_GET['w4e_settings_saved']);
+        // phpcs:enable
+        $settings = (array) get_option('woo4etch_settings', []);
+        $disabled_styles = !empty($settings['disable_woo_styles']);
+        ?>
+        <h2 class="category-heading"><?php esc_html_e('Settings', 'woo4etch'); ?></h2>
+
+        <?php if ($saved) : ?>
+            <div class="notice notice-success inline"><p><?php esc_html_e('Settings saved.', 'woo4etch'); ?></p></div>
+        <?php endif; ?>
+
+        <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>">
+            <input type="hidden" name="action" value="woo4etch_save_settings">
+            <?php wp_nonce_field('woo4etch_save_settings'); ?>
+            <table class="form-table" role="presentation">
+                <tr>
+                    <th scope="row"><?php esc_html_e('WooCommerce styles', 'woo4etch'); ?></th>
+                    <td>
+                        <label>
+                            <input type="checkbox" name="disable_woo_styles" value="1" <?php checked($disabled_styles); ?>>
+                            <?php esc_html_e('Disable WooCommerce default styles', 'woo4etch'); ?>
+                        </label>
+                        <p class="description">
+                            <?php esc_html_e('Removes all three WooCommerce stylesheets (layout, smallscreen, general) so your Etch styles start from a blank slate — no specificity fights, no !important. Uncheck to bring the Woo default styling back at any time. Note: payment gateways and some extensions enqueue their own CSS and are not affected. Developers can override this via the woo4etch/disable_woo_styles filter.', 'woo4etch'); ?>
+                        </p>
+                    </td>
+                </tr>
+            </table>
+            <?php submit_button(__('Save settings', 'woo4etch')); ?>
+        </form>
+        <?php
     }
 
     /**
@@ -273,6 +332,8 @@ final class Woo4Etch_Admin {
                     </a>
                 </p>
             </div>
+
+            <?php self::render_settings_section(); ?>
 
             <?php self::render_layouts_section(); ?>
 

--- a/plugin/woo4etch/readme.txt
+++ b/plugin/woo4etch/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, etch, shortcodes, page-builder
 Requires at least: 6.0
 Tested up to: 6.7
 Requires PHP: 7.4
-Stable tag: 1.5.0-beta.2
+Stable tag: 1.5.0-beta.3
 License: MIT
 License URI: https://opensource.org/licenses/MIT
 
@@ -113,6 +113,11 @@ WooCommerce must be installed and active.
 In the admin, open **Etch → Woo4Etch** for a table of all shortcodes with copy buttons (or **WooCommerce → Woo4Etch** when Etch is not active).
 
 == Changelog ==
+
+= 1.5.0-beta.3 =
+* Buy-now flow built in: a submit button name="buy_now" inside form.cart sends the customer straight to checkout after the normal add-to-cart — no snippet needed. Filters: woo4etch/enable_buy_now (default on), woo4etch/buy_now_empty_cart (default off; opt in for true one-click checkout where the cart is emptied first).
+* Variation swatches, Etch-native: new bundled script (assets/swatches.js, enqueued on product pages) bridges clicks on your own Etch-built swatch markup (data-w4e-swatch / data-attribute / data-value) to the hidden native attribute select, so WooCommerce's variation logic (price, stock, variation_id) keeps working untouched. Selected state via .is-selected + aria-pressed; Woo's "Clear" link resets the swatches. Filter: woo4etch/enqueue_swatches.
+* New Settings section (Etch → Woo4Etch): checkbox "Disable WooCommerce default styles" removes all three Woo stylesheets so Etch styles start from a blank slate — and brings them back when unchecked. Filter override: woo4etch/disable_woo_styles.
 
 = 1.5.0-beta.2 =
 * Ready-made layouts with one-click install: Etch → Woo4Etch → Ready-made layouts ships complete, editable Etch layouts for cart, single product, shop archive, header mini-cart, My Account and thank-you. "Install as pattern" adds them to Etch's pattern library (category Woo4Etch, unsynced) and merges their classes into Etch's style system — existing styles with the same selector are reused, never overwritten. "Copy JSON" exports Etch's native paste format. All layouts are built on the dynamic-data bridges, so they preview live in the builder.

--- a/plugin/woo4etch/woo4etch.php
+++ b/plugin/woo4etch/woo4etch.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Woo4Etch
  * Plugin URI:        https://github.com/tobiashaas/woo4etch
  * Description:       WooCommerce shortcodes and customization layer for Etch templates — [do_action], prices, stock, add-to-cart, gallery, conditionals, archive, and Woo data as Etch dynamic data (cart, account, orders).
- * Version:           1.5.0-beta.2
+ * Version:           1.5.0-beta.3
  * Requires at least: 6.0
  * Requires PHP:      7.4
  * Requires Plugins:  woocommerce
@@ -123,7 +123,7 @@ add_action('plugins_loaded', static function () {
 final class Woo4Etch {
 
     /** Plugin version. */
-    const VERSION = '1.5.0-beta.2';
+    const VERSION = '1.5.0-beta.3';
 
     /**
      * Register all shortcodes and the admin reference screen.
@@ -150,6 +150,8 @@ final class Woo4Etch {
         // the same seam Etch's own integration uses for gallery_images.
         // Disable: woo4etch/expose_product_data.
         add_filter('etch/dynamic_data/post', [__CLASS__, 'expose_product_data'], 10, 2);
+
+        self::register_frontend_features();
 
         if (is_admin()) {
             Woo4Etch_Admin::init();
@@ -641,6 +643,87 @@ final class Woo4Etch {
                 'example'     => '[shop_messages]',
             ],
         ]);
+    }
+
+    /* ============================================================
+       Frontend behaviours (no markup — they only support your Etch layout)
+       ============================================================ */
+
+    /**
+     * Register the frontend behaviours: optional Woo-CSS removal (admin
+     * checkbox), the buy-now → checkout redirect, and the variation-swatch
+     * sync script. None of these output markup; the layout stays yours.
+     */
+    private static function register_frontend_features() {
+        // Drop WooCommerce's three stylesheets so Etch styles start from a
+        // blank slate. Driven by the admin checkbox (Woo4Etch → Settings);
+        // the filter wins over the option either way:
+        //   add_filter('woo4etch/disable_woo_styles', '__return_true');
+        $settings = (array) get_option('woo4etch_settings', []);
+        if (apply_filters('woo4etch/disable_woo_styles', !empty($settings['disable_woo_styles']))) {
+            add_filter('woocommerce_enqueue_styles', '__return_empty_array', 20);
+        }
+
+        // Buy-now flow: a second submit button inside form.cart —
+        //   <button type="submit" name="buy_now" value="1" class="single_add_to_cart_button">Buy now</button>
+        // WooCommerce adds the product as usual; we only redirect to checkout.
+        // Disable: add_filter('woo4etch/enable_buy_now', '__return_false');
+        if (apply_filters('woo4etch/enable_buy_now', true)) {
+            add_filter('woocommerce_add_to_cart_redirect', [__CLASS__, 'buy_now_redirect'], 20);
+            add_action('wp_loaded', [__CLASS__, 'buy_now_maybe_empty_cart'], 15);
+        }
+
+        add_action('wp_enqueue_scripts', [__CLASS__, 'enqueue_swatches_script']);
+    }
+
+    /**
+     * Send buy-now submissions straight to checkout after the add-to-cart.
+     *
+     * @param string|false $url Redirect URL WooCommerce decided on.
+     * @return string|false
+     */
+    public static function buy_now_redirect($url) {
+        // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Woo's own add-to-cart flow has no nonce.
+        if (!empty($_REQUEST['buy_now']) && function_exists('wc_get_checkout_url')) {
+            return wc_get_checkout_url();
+        }
+        return $url;
+    }
+
+    /**
+     * Optionally start buy-now with an empty cart (true one-click checkout).
+     * Off by default — opt in: add_filter('woo4etch/buy_now_empty_cart', '__return_true');
+     * Runs before WooCommerce's add-to-cart handler (wp_loaded, 20).
+     */
+    public static function buy_now_maybe_empty_cart() {
+        // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Woo's own add-to-cart flow has no nonce.
+        if (empty($_REQUEST['buy_now']) || empty($_REQUEST['add-to-cart'])) {
+            return;
+        }
+        if (apply_filters('woo4etch/buy_now_empty_cart', false) && WC()->cart) {
+            WC()->cart->empty_cart();
+        }
+    }
+
+    /**
+     * Variation-swatch sync script: clicks on [data-w4e-swatch] elements set
+     * the matching attribute <select> inside form.variations_form and trigger
+     * Woo's variation JS. The swatch markup itself is built in Etch (loop over
+     * the attribute terms) — the script only bridges clicks to the hidden select.
+     * Scope/disable: add_filter('woo4etch/enqueue_swatches', '__return_false');
+     */
+    public static function enqueue_swatches_script() {
+        $enqueue = function_exists('is_product') && is_product();
+        if (!apply_filters('woo4etch/enqueue_swatches', $enqueue)) {
+            return;
+        }
+        wp_enqueue_script(
+            'woo4etch-swatches',
+            plugins_url('assets/swatches.js', __FILE__),
+            [],
+            self::VERSION,
+            true
+        );
     }
 
     /* ============================================================

--- a/templates/00-README.md
+++ b/templates/00-README.md
@@ -35,6 +35,8 @@ All templates follow the same structure:
 | `13-useful-snippets.md` | Buy-now button, custom add-to-cart URLs, free-shipping bar, refund request, more |
 | `14-visual-hook-guides.md` | Links to Business Bloomer's annotated hook diagrams |
 | `15-woo4etch-plugin.md` | **Woo4Etch** plugin (shortcodes + customizations) |
+| `16-one-click-checkout.md` | One-click checkout (Buy Now → checkout → thank-you) |
+| `17-components.md` | Component blueprints with pre-wired Woo markup |
 | `functions-snippets.md` | Consolidated PHP snippets from all templates |
 | `etch-copy/` | Copy/paste Etch snippets — paste a ready-made layout (e.g. the full cart) into the builder |
 
@@ -84,11 +86,13 @@ The plugin lives at [`../plugin/woo4etch/`](../plugin/woo4etch/).
 
 ### Disable default Woo CSS (optional, recommended for custom markup)
 
+> Easiest way: the checkbox under **Etch → Woo4Etch → Settings → Disable WooCommerce default styles** (Woo4Etch 1.5.0-beta.3+) — togglable any time, no code. Snippet alternative:
+
 ```php
 add_filter('woocommerce_enqueue_styles', '__return_empty_array');
 ```
 
-Keeps your own styling clean without Woo defaults interfering.
+Keeps your own styling clean without Woo defaults interfering. Don't fight Woo's CSS with overrides — remove it and style on a blank slate. (See also [`../docs/ADR-001-no-template-overrides.md`](../docs/ADR-001-no-template-overrides.md) for why Woo4Etch never overrides Woo template files.)
 
 ### Replace Woo content wrappers
 

--- a/templates/01-single-product-simple.md
+++ b/templates/01-single-product-simple.md
@@ -45,9 +45,12 @@ add_filter('woocommerce_enqueue_styles', '__return_empty_array');
         <meta itemprop="priceCurrency" content="EUR">
       </p>
 
-      <p class="woocommerce-product-details__short-description" itemprop="description">
+      <!-- Use a RAW HTML element for the excerpt, not a Paragraph/Text element:
+           Woo short descriptions may contain HTML (<strong>, <br>, lists), and
+           Etch text blocks escape it — the tags would show as literal text. -->
+      <div class="woocommerce-product-details__short-description" itemprop="description">
         {this.excerpt}
-      </p>
+      </div>
     </header>
 
     <div class="product__layout">
@@ -245,6 +248,7 @@ If you want real AJAX, intercept the submit via JS and post to `wc-ajax=add_to_c
 
 ## Common mistakes
 
+- Excerpt rendered in a Paragraph/Text element → HTML in the short description (`<strong>`, `<br>`, lists) shows as literal text. Use a **Raw HTML** element for `{this.excerpt}`.
 - Quantity input without `name="quantity"` → quantity doesn't end up in the cart.
 - Forgot `value` on the submit button → server doesn't know *which* product.
 - `form.cart` replaced by `<div>` → Woo doesn't recognise the form.

--- a/templates/02-single-product-variable.md
+++ b/templates/02-single-product-variable.md
@@ -247,6 +247,43 @@ add_action('init', function () {
 
 Keep the price-area callback (priority 10) active — it writes into the `.single_variation` div.
 
+### Variation swatches (color blobs / image previews)
+
+WooCommerce default offers only the bare `<select>` dropdowns. With Woo4Etch **1.5.0-beta.3+** you can render swatches as your own Etch markup — fully visible and styleable in the builder — and the plugin's bundled script bridges clicks to the hidden native select, so Woo's variation logic (price, stock, `variation_id`) keeps working untouched.
+
+**1. Keep the native `<select>` in the form** (hide it with CSS, don't remove it):
+
+```css
+.variations_form select[name^="attribute_"] { position: absolute; left: -9999px; }
+```
+
+**2. Render the swatches in Etch** — loop the attribute terms (`wp-terms` loop on the taxonomy, e.g. `pa_color`) and give each clickable element three data attributes:
+
+```html
+{#loop colorTerms as term}
+  <button type="button"
+          class="swatch swatch--color"
+          data-w4e-swatch
+          data-attribute="attribute_pa_color"
+          data-value="{term.slug}"
+          aria-pressed="false"
+          aria-label="{term.name}"
+          style="background-color: {term.meta.color}">
+  </button>
+{/loop}
+```
+
+Store the color value (or an image) as term meta on the attribute term (Etch CMS field or ACF) and use it freely in the markup — circles, pills, image thumbs, whatever you style.
+
+**3. Done.** The plugin script (`assets/swatches.js`, enqueued on product pages) sets the matching select value on click, triggers Woo's `change` handling, toggles `.is-selected` + `aria-pressed` on the active swatch, and clears all swatches when Woo's "Clear" link fires `reset_data`.
+
+```php
+// Scope or disable the script:
+add_filter('woo4etch/enqueue_swatches', '__return_false');
+```
+
+Style the selected state in Etch via `.swatch.is-selected`.
+
 ### Swap variation image (optional)
 
 By default Woo swaps the gallery image on variant change. If you have a custom gallery, listen to the event:

--- a/templates/04-cart.md
+++ b/templates/04-cart.md
@@ -245,6 +245,23 @@ In WooCommerce settings, switch the cart page to the **classic shortcode**:
 
 ## PHP layer
 
+### Remove the duplicate Gutenberg page title
+
+On the page WooCommerce assigns as Cart, the block templates (`woocommerce/page-content-wrapper`) auto-render a `<h1 class="wp-block-post-title">` above your content. With your own `<h1>` in the Etch layout the heading appears twice — and the Gutenberg one is not visible/editable in Etch. Suppress it in `customizations.php`:
+
+```php
+// Drop the auto-rendered post title on Woo pages (cart/checkout/account) —
+// the Etch layout brings its own <h1>.
+add_filter('render_block', function ($content, $block) {
+    if (($block['blockName'] ?? '') === 'core/post-title'
+        && function_exists('is_cart')
+        && (is_cart() || is_checkout() || is_account_page())) {
+        return '';
+    }
+    return $content;
+}, 10, 2);
+```
+
 ### Pass cart data to Etch
 
 Etch normally gets standard items from the WP loop. The cart contents you need to inject yourself via a render hook or load via AJAX/REST. Minimal REST endpoint:
@@ -336,6 +353,7 @@ jQuery(function ($) {
 
 ## Common mistakes
 
+- Duplicate `<h1>` on the cart page — Gutenberg's `wp-block-post-title` renders above your Etch layout. Remove it with the `render_block` snippet in the PHP layer above.
 - `name="cart[<key>][qty]"` replaced by custom names → update doesn't process quantities.
 - Cart nonce missing or stale → update rejected with "security check failed".
 - Coupon button not named `apply_coupon` → code isn't applied.

--- a/templates/10-etch-context-and-templates.md
+++ b/templates/10-etch-context-and-templates.md
@@ -165,8 +165,21 @@ The inner `item.gallery_images` is read from the outer loop's current `item`; in
 > **In a Loop** → "I'm iterating; the current one is `item` → `{item.title}`."
 > **On a Page** → "Etch knows nothing specific; I either use `{user.*}` / `{site.*}`, or I bring my own data source."
 
+## Condition blocks hide content in the builder
+
+Content inside an Etch condition (`{#if …}`) is invisible — and therefore not editable — in the builder whenever the condition is false in the builder's preview context (e.g. *is on sale*, *in stock*, a chosen variation). Removing the condition to edit and re-adding it afterwards is error-prone.
+
+Workarounds, in order of preference:
+
+1. **Preview with a "fully loaded" product.** Set the template preview to a test product that satisfies every condition you use: on sale, in stock, with gallery, with variations. All condition branches become visible at once.
+2. **Build first, condition last.** Author the markup unconditioned, style it, and wrap it in the condition as the final step.
+3. **Temporarily invert instead of remove.** To edit the *false* branch, flip the condition (`!`) rather than deleting it — flipping back is harder to forget than re-creating the whole condition.
+
+The Woo4Etch dynamic-data bridges already help here: cart, account, and order loops return **sample data inside the builder**, so those layouts preview without a real shopping session.
+
 ## Common mistakes
 
+- Content inside a `{#if …}` condition seems to have vanished in the builder — the condition is false for the previewed item. See "Condition blocks hide content in the builder" above; don't rebuild the markup, change the preview product.
 - Writing `{item.title}` on a Single template (outside any loop). Etch doesn't know what `item` refers to → empty output.
 - Writing `{this.title}` inside a `{#loop … as item}` block. `this` still points to the template's main item (the archive), not the loop's current product → wrong title.
 - Forgetting to wrap card markup in `{#loop mainQuery as item}` on an archive template → only the first row renders or nothing at all.

--- a/templates/13-useful-snippets.md
+++ b/templates/13-useful-snippets.md
@@ -27,6 +27,8 @@ Behind the scenes, WooCommerce's "URL add-to-cart" handler runs on `wp_loaded`. 
 
 ## "Buy Now" button (skip the cart, go straight to checkout)
 
+> **Built into the Woo4Etch plugin since 1.5.0-beta.3** — a submit button `name="buy_now"` inside `form.cart` is all you need; see [`16-one-click-checkout.md`](./16-one-click-checkout.md). The snippet below remains for plugin-free setups:
+
 ```php
 add_action('woocommerce_after_add_to_cart_button', 'kr_buy_now_button');
 function kr_buy_now_button() {

--- a/templates/15-woo4etch-plugin.md
+++ b/templates/15-woo4etch-plugin.md
@@ -62,6 +62,21 @@ See the plain-language explanation in [`00-README.md`](./00-README.md#declare-wo
 | Product loop pagination on an archive | **Woo4Etch** — `[woo_pagination]` |
 | Output a WooCommerce template part | **Woo4Etch** — `[woo_template name="single-product/related"]` |
 
+## Settings (admin checkbox)
+
+Under **Etch → Woo4Etch → Settings**:
+
+- **Disable WooCommerce default styles** — removes all three Woo stylesheets (`woocommerce-layout`, `woocommerce-smallscreen`, `woocommerce-general`) so your Etch styles start from a blank slate: no specificity fights, no `!important`. Uncheck to bring the Woo styling back at any time. Payment gateways and some extensions enqueue their own CSS and are not affected. Developers can override programmatically: `add_filter('woo4etch/disable_woo_styles', '__return_true');` (the filter wins over the checkbox).
+
+## Built-in frontend behaviours (no markup)
+
+These ship with the plugin and never output HTML — they only support your own Etch markup:
+
+| Behaviour | Trigger in your markup | Filters |
+|---|---|---|
+| **Buy-now → checkout redirect** | a submit button `name="buy_now"` inside `form.cart` (see [`16-one-click-checkout.md`](./16-one-click-checkout.md)) | `woo4etch/enable_buy_now` (default on), `woo4etch/buy_now_empty_cart` (default off) |
+| **Variation swatch sync** | clickable elements with `data-w4e-swatch`, `data-attribute`, `data-value` (see [`02-single-product-variable.md`](./02-single-product-variable.md#variation-swatches-color-blobs--image-previews)) | `woo4etch/enqueue_swatches` (default: product pages) |
+
 ## Ready-made layouts (install as Etch patterns)
 
 Under **Etch → Woo4Etch → Ready-made layouts** the plugin ships complete, editable Etch layouts for every shop area — cart, single product, shop archive, header mini-cart, My Account and thank-you. All of them are built on the dynamic-data bridges (no shortcodes except where real Woo PHP is required), so they render live in the builder canvas.

--- a/templates/16-one-click-checkout.md
+++ b/templates/16-one-click-checkout.md
@@ -1,0 +1,92 @@
+# 16 — One-Click Checkout (Buy Now)
+
+A "Buy now" button on the single product page that adds the product and sends the customer straight to checkout, skipping the cart. The flow ends on the thank-you page ([`08-thank-you.md`](./08-thank-you.md)) — works for guests too.
+
+## When to use
+
+- Single-product shops or impulse-buy products where the cart is friction.
+- Alongside the normal add-to-cart button (both can coexist in the same form).
+- Combined with `woo4etch/buy_now_empty_cart` for a true one-click flow (the new product replaces the cart).
+
+## Preparation
+
+- Woo4Etch plugin **1.5.0-beta.3+** active — the buy-now redirect is built in (no snippet required).
+- A working add-to-cart form from [`01-single-product-simple.md`](./01-single-product-simple.md) or [`02-single-product-variable.md`](./02-single-product-variable.md).
+- Checkout page assigned under WooCommerce → Settings → Advanced.
+
+## Etch HTML
+
+Add a second submit button **inside the existing `form.cart`** (or `form.variations_form`):
+
+```html
+<form class="cart" action="{this.permalink.relative}" method="post" enctype="multipart/form-data">
+
+  <input type="number" name="quantity" value="1" min="1" step="1" aria-label="Quantity">
+
+  <button type="submit"
+          name="add-to-cart"
+          value="{this.id}"
+          class="single_add_to_cart_button button alt">
+    Add to cart
+  </button>
+
+  <!-- Buy now: same form, extra flag. The plugin redirects to checkout. -->
+  <button type="submit"
+          name="buy_now"
+          value="1"
+          class="single_add_to_cart_button button buy-now-button">
+    Buy now
+  </button>
+
+  <!-- The add-to-cart value must still be submitted when buy_now is clicked.
+       Browsers only submit the *clicked* submit button, so carry the product
+       id in a hidden input instead of relying on the other button: -->
+  <input type="hidden" name="add-to-cart" value="{this.id}">
+</form>
+```
+
+> If you keep the hidden `add-to-cart` input, change the regular button to `type="submit"` **without** a `name` (or keep both — duplicate `add-to-cart` values are harmless since they're identical).
+
+## Required classes / attributes
+
+| Selector / attribute | Required | Why |
+|---|---|---|
+| `form.cart` | yes | Woo's add-to-cart handler keys off the form |
+| `name="add-to-cart"` + `value="{this.id}"` | yes | Tells the server which product (hidden input recommended) |
+| `name="buy_now"` | yes | The flag the Woo4Etch redirect checks (`$_REQUEST['buy_now']`) |
+| `name="quantity"` | yes | Quantity ends up in the cart |
+| `.single_add_to_cart_button` | yes | Woo JS/extensions hook onto it |
+
+## Hooks used
+
+None beyond the standard add-to-cart hooks — the buy-now button lives inside the same form, so `woocommerce_before_add_to_cart_button` / `woocommerce_after_add_to_cart_button` apply unchanged.
+
+## PHP layer
+
+Built into the Woo4Etch plugin — when the submitted request contains `buy_now`, the customer is redirected to checkout after the (normal, validated) add-to-cart:
+
+```php
+// Disable the built-in buy-now redirect:
+add_filter('woo4etch/enable_buy_now', '__return_false');
+
+// True one-click: empty the cart first, so checkout contains only this product.
+// Off by default — existing cart contents are preserved.
+add_filter('woo4etch/buy_now_empty_cart', '__return_true');
+```
+
+No snippet in `customizations.php` is needed for the default behaviour.
+
+## Common mistakes
+
+- Buy-now button placed **outside** `form.cart` → nothing is added; the flag never reaches Woo's handler.
+- Product id only on the regular button (`name="add-to-cart"` on the *other* submit button) → browsers submit only the clicked button, the server doesn't know the product. Use the hidden input.
+- Expecting the cart to be emptied — that's opt-in via `woo4etch/buy_now_empty_cart`.
+- Variable products: buy-now works the same inside `form.variations_form`, but a variation must be selected first (Woo validates this server-side and bounces back with a notice — render `[woo_notices]`).
+
+## Test checklist
+
+- Click "Buy now" → product is in the cart and the browser lands on checkout.
+- Click the regular "Add to cart" → normal behaviour (stays on / redirects per Woo settings).
+- Guest checkout: complete an order without an account → thank-you page renders ([`08-thank-you.md`](./08-thank-you.md)).
+- With `buy_now_empty_cart` enabled: pre-fill the cart, buy-now another product → checkout shows only the new product.
+- Variable product without a chosen variation: buy-now shows Woo's "select options" notice instead of a broken checkout.

--- a/templates/17-components.md
+++ b/templates/17-components.md
@@ -1,0 +1,100 @@
+# 17 — Component Blueprints (pre-wired Woo markup)
+
+Etch **Components** with the critical WooCommerce attributes already wired in. Build each blueprint once as a component in your install, then reuse it everywhere — you style and arrange freely, while the "invisible contract" with Woo's server logic (`form.cart`, `name="add-to-cart"`, …) stays intact inside the component.
+
+## When to use
+
+- You don't want to (re-)remember which classes/attributes Woo's server logic requires.
+- Several templates need the same add-to-cart/quantity/buy-now building blocks.
+- Team setups: designers restyle components without being able to forget a required attribute by accident.
+
+## Preparation
+
+- Etch with Components (stored as `wp_block` CPT) — props + slots supported.
+- Woo4Etch plugin active (`[do_action]`, buy-now redirect, dynamic data).
+
+## Blueprints
+
+Create each as an Etch component; expose the marked parts as **props** and the free areas as **slots**.
+
+### Add to Cart (simple product)
+
+```html
+<form class="cart" action="{this.permalink.relative}" method="post" enctype="multipart/form-data">
+  <!-- Slot: before-button (trust badges, delivery estimate, …) -->
+
+  <input type="number"
+         name="quantity"
+         value="1" min="1" step="1"
+         class="input-text qty text"
+         aria-label="Quantity">
+
+  <button type="submit"
+          name="add-to-cart"
+          value="{this.id}"
+          class="single_add_to_cart_button button alt">
+    Add to cart            <!-- Prop: button label -->
+  </button>
+
+  <!-- Slot: after-button -->
+</form>
+```
+
+### Quantity input (standalone)
+
+```html
+<div class="quantity">
+  <input type="number"
+         name="quantity"
+         value="1" min="1" step="1"
+         class="input-text qty text"
+         aria-label="Quantity">
+</div>
+```
+
+### Buy Now button (inside an existing `form.cart`)
+
+```html
+<button type="submit"
+        name="buy_now"
+        value="1"
+        class="single_add_to_cart_button button buy-now-button">
+  Buy now                  <!-- Prop: button label -->
+</button>
+<input type="hidden" name="add-to-cart" value="{this.id}">
+```
+
+See [`16-one-click-checkout.md`](./16-one-click-checkout.md) for the full flow.
+
+## Required classes / attributes — never change these inside the components
+
+| Attribute / class | Component | Why |
+|---|---|---|
+| `form.cart` (the class!) | Add to Cart | Woo's handler keys off it |
+| `name="add-to-cart"` + `value="{this.id}"` | Add to Cart, Buy Now | Which product to add |
+| `name="quantity"` | Add to Cart, Quantity | Quantity ends up in the cart |
+| `name="buy_now"` | Buy Now | The flag the Woo4Etch redirect checks |
+| `.single_add_to_cart_button` | buttons | Woo JS + extensions hook onto it |
+| `method="post"` + `enctype="multipart/form-data"` | Add to Cart | Add-ons (file upload) break without it |
+
+Everything **not** in this table — wrappers, classes you add, order, labels, slots — is yours.
+
+## Hooks used
+
+Place `[do_action hook="woocommerce_before_add_to_cart_button"]` / `…after_add_to_cart_button` inside the form (e.g. in the slots) if extensions should inject content.
+
+## PHP layer
+
+None required. Optional: the buy-now filters from [`16-one-click-checkout.md`](./16-one-click-checkout.md).
+
+## Common mistakes
+
+- Editing a required attribute *inside* the component "just to rename it" → every instance breaks at once. The table above is the do-not-touch list.
+- Recreating the markup per template instead of instancing the component → drift; fixes no longer propagate.
+- Buy Now component used outside a `form.cart` → submits nothing.
+
+## Test checklist
+
+- Insert each component on a product template; add to cart works (product + quantity correct in cart).
+- Restyle a component instance (colors, spacing, order) → still functional.
+- With an extension active (e.g. Product Add-ons): hook output appears inside the form.

--- a/templates/functions-snippets.md
+++ b/templates/functions-snippets.md
@@ -36,8 +36,25 @@ add_action('after_setup_theme', function () {
 
 ### Disable WooCommerce default styles
 
+> Since Woo4Etch 1.5.0-beta.3 this is a checkbox in the plugin admin (**Woo4Etch → Settings → Disable WooCommerce default styles**) — no snippet needed, and you can bring the Woo styling back at any time. The snippet remains as an alternative:
+
 ```php
 add_filter('woocommerce_enqueue_styles', '__return_empty_array');
+```
+
+### Remove the duplicate Gutenberg page title (cart/checkout/account)
+
+WooCommerce's block templates auto-render a `<h1 class="wp-block-post-title">` above your content; with your own `<h1>` in Etch the heading appears twice:
+
+```php
+add_filter('render_block', function ($content, $block) {
+    if (($block['blockName'] ?? '') === 'core/post-title'
+        && function_exists('is_cart')
+        && (is_cart() || is_checkout() || is_account_page())) {
+        return '';
+    }
+    return $content;
+}, 10, 2);
 ```
 
 ### Replace WooCommerce content wrappers


### PR DESCRIPTION
## v1.5.0-beta.3 — Buy Now, Variation Swatches, Woo-CSS-Checkbox + Doku-Fixes

Setzt die Issues #1–#8 um und bereitet den Beta-3-Release vor (Tag `v1.5.0-beta.3` nach dem Merge pushen, siehe `.github/RELEASE.md`).

### Plugin (1.5.0-beta.3)

- **Buy-Now eingebaut** (#2): Submit-Button `name="buy_now"` in `form.cart` genügt — Redirect zur Kasse nach normalem, validiertem Add-to-Cart. Filter: `woo4etch/enable_buy_now`, `woo4etch/buy_now_empty_cart` (opt-in für echtes One-Click mit geleertem Warenkorb).
- **Variation Swatches, Etch-nativ** (#7): `assets/swatches.js` verbindet eigene Etch-Swatch-Markups (`data-w4e-swatch`/`data-attribute`/`data-value`) mit dem versteckten nativen `<select>` — Woo-Variantenlogik bleibt unangetastet. Filter: `woo4etch/enqueue_swatches`.
- **Settings-Checkbox** (#8): „Disable WooCommerce default styles" entfernt alle drei Woo-Stylesheets — und holt sie per Unchecken zurück. Filter: `woo4etch/disable_woo_styles`.

### Dokumentation

- `templates/16-one-click-checkout.md` — kompletter Flow Buy Now → Checkout → Thank You inkl. Gast-Checkout-Checkliste (#2)
- `templates/17-components.md` — Component-Blueprints mit den unantastbaren Woo-Attributen (#6)
- `docs/ADR-001-no-template-overrides.md` — Schichttrennung Layout (User) / Logik (Plugin) (#5)
- Excerpt als Raw-HTML-Element statt Paragraph (#1, `01-single-product-simple.md`)
- Snippet gegen die doppelte Gutenberg-H1 auf Cart/Checkout/Account (#3, `04-cart.md` + `functions-snippets.md`)
- Workarounds für unsichtbare Condition-Block-Inhalte im Builder (#4, `10-etch-context-and-templates.md`)
- Indizes, Plugin-Referenz (15), Changelogs und Versionskonstanten synchron

Closes #1, Closes #2, Closes #3, Closes #4, Closes #5, Closes #6, Closes #7, Closes #8

https://claude.ai/code/session_014LFFGVmJXeP1tJQYrooVC9

---
_Generated by [Claude Code](https://claude.ai/code/session_014LFFGVmJXeP1tJQYrooVC9)_