### PR TITLE
Release v1.5.0-beta.6: PHP 8.1 floor + regenerated copy/paste layouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); ver
 
 Releases are published as [GitHub Releases](https://github.com/tobiashaas/woo4etch/releases); regular plugin installs self-update from there. The same changelog ships inside the plugin in `plugin/woo4etch/readme.txt` — keep both in sync.
 
+## [1.5.0-beta.6] — 2026-06-13
+
+Pre-release — not offered to installed sites via the auto-updater; install manually to test.
+
+### Changed
+
+- **Minimum PHP is now 8.1** (header `Requires PHP`, `readme.txt`, updater fallbacks). Etch itself requires PHP 8.1, so the older 7.4/8.0 floor was dead weight. No code changed — the plugin already ran on 8.1+.
+
+### Fixed
+
+- **Copy/paste layout artifacts were out of sync with the plugin's layouts.** The `templates/etch-copy/*.json` files are generated from the layout definitions, but two had drifted: `product-grid.json` still carried the broken raw `mainQuery` loop target (so a pasted shop archive rendered no products — the same bug fixed for the one-click installer in beta.5, but the copy/paste file was never regenerated), and `product-single.json` still had the pre-beta.5 gallery markup and an escaped (text-element) excerpt. Both regenerated to match the current layouts. The one-click installer was unaffected; this only fixes the manual copy/paste route.
+
+### Internal
+
+- **CI test layer (no WordPress required).** A fast, service-free GitHub Actions job (`tests/php/`) now gates every PR: version-marker sync (`Version` header == `Woo4Etch::VERSION` == `Stable tag`), shortcode-catalog integrity (every entry maps to an existing `shortcode_*` method; every shortcode documented), and layout DSL invariants — most importantly that every `etch/loop` binds to a data path or a `loopId`, never a bare query key like `mainQuery` (the empty-archive bug). A drift guard re-runs `tools/generate-etch-copy.php` and fails if the committed copy/paste artifacts change. The PHP lint matrix now runs 8.1 → 8.5. See `tests/php/README.md`.
+
 ## [1.5.0-beta.5] — 2026-06-12
 
 Pre-release — not offered to installed sites via the auto-updater; install manually to test. Everything below was verified live on a staging shop (Etch 1.5.1, WooCommerce 10.8.1, block theme, Germanized).

--- a/plugin/woo4etch/readme.txt
+++ b/plugin/woo4etch/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, etch, shortcodes, page-builder
 Requires at least: 6.0
 Tested up to: 6.7
 Requires PHP: 8.1
-Stable tag: 1.5.0-beta.5
+Stable tag: 1.5.0-beta.6
 License: MIT
 License URI: https://opensource.org/licenses/MIT
 
@@ -114,6 +114,11 @@ WooCommerce must be installed and active.
 In the admin, open **Etch → Woo4Etch** for a table of all shortcodes with copy buttons (or **WooCommerce → Woo4Etch** when Etch is not active).
 
 == Changelog ==
+
+= 1.5.0-beta.6 =
+* Minimum PHP is now 8.1 (Etch itself requires it; 7.4/8.0 support was dead weight). No code changed — the plugin already ran on 8.1+.
+* Fix: the copy/paste layout files (templates/etch-copy/*.json) were out of sync with the plugin's layouts — product-grid.json still had the broken mainQuery loop target (a pasted shop archive showed no products; fixed for the one-click installer in beta.5 but the copy/paste file was never regenerated) and product-single.json had the pre-beta.5 gallery + escaped excerpt. Both regenerated. The one-click installer was unaffected.
+* Internal: a fast, WordPress-free CI test layer now gates every PR (version-marker sync, shortcode-catalog integrity, layout loop/Woo-contract invariants, and a copy/paste-artifact drift guard); PHP lint matrix runs 8.1 → 8.5.
 
 = 1.5.0-beta.5 =
 * Experimental {woo.*} dynamic-data root: the shop data from {options.*} additionally under a namespaced, structured root — {woo.cart.items}, {woo.cart.count}, {woo.checkout.url}, {woo.account.menu}, {woo.account.orders}, {woo.order}, … Same values and builder sample data as {options.*}; lazy registration; fully guarded against Etch internals changing (then the woo root disappears while {options.*} keeps working — options.* remains the documented spelling). Filters: woo4etch/enable_woo_root, woo4etch/woo_root_data.

--- a/plugin/woo4etch/woo4etch.php
+++ b/plugin/woo4etch/woo4etch.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Woo4Etch
  * Plugin URI:        https://github.com/tobiashaas/woo4etch
  * Description:       WooCommerce shortcodes and customization layer for Etch templates — [do_action], prices, stock, add-to-cart, gallery, conditionals, archive, and Woo data as Etch dynamic data (cart, account, orders).
- * Version:           1.5.0-beta.5
+ * Version:           1.5.0-beta.6
  * Requires at least: 6.0
  * Requires PHP:      8.1
  * Requires Plugins:  woocommerce
@@ -176,7 +176,7 @@ add_action('plugins_loaded', static function () {
 final class Woo4Etch {
 
     /** Plugin version. */
-    const VERSION = '1.5.0-beta.5';
+    const VERSION = '1.5.0-beta.6';
 
     /**
      * Register all shortcodes and the admin reference screen.


### PR DESCRIPTION
Version bump and changelog for the changes already merged to `main`.

## Changed
- **Version 1.5.0-beta.5 → 1.5.0-beta.6** (header `Version:`, `Woo4Etch::VERSION`, `readme.txt` Stable tag — all kept in sync, enforced by the consistency test).
- Changelog entries in both `CHANGELOG.md` and `plugin/woo4etch/readme.txt`.

## Covers (already on main)
- Minimum PHP raised to **8.1** (Etch's floor); CI lint matrix **8.1 → 8.5**.
- Fast, WordPress-free CI test layer + copy/paste drift guard (#10).
- Regenerated `templates/etch-copy/product-grid.json` / `product-single.json` that had drifted from the layouts.

## Follow-ups filed
- #12 — wp-env / wp-phpunit integration tests (layers 4–5 of #10)
- #13 — product-grid copy/paste `loopId` portability

> Maintainer note: per `.github/RELEASE.md`, tagging `v1.5.0-beta.6` after merge triggers the release workflow (GitHub pre-release, not pushed to installed sites).