### PR TITLE
Feat/expose sold individually

### DIFF
--- a/plugin/woo4etch/woo4etch.php
+++ b/plugin/woo4etch/woo4etch.php
@@ -2157,7 +2157,7 @@ final class Woo4Etch {
      *   stock_label                — localized availability text (may be empty for
      *                                in-stock products, per Woo inventory settings)
      *   stock_quantity (int|''), is_in_stock (bool)
-     *   is_purchasable, is_featured (bool)
+     *   is_purchasable, is_featured, is_sold_individually (bool)
      *   rating (float), rating_count, review_count (int)
      *   add_to_cart_url, add_to_cart_text
      *   weight, dimensions         — formatted; empty when not set
@@ -2227,6 +2227,7 @@ final class Woo4Etch {
             'is_in_stock'      => $product->is_in_stock(),
             'is_purchasable'   => $product->is_purchasable(),
             'is_featured'      => $product->is_featured(),
+            'is_sold_individually' => $product->is_sold_individually(),
             'rating'           => (float) $product->get_average_rating(),
             'rating_count'     => (int) $product->get_rating_count(),
             'review_count'     => (int) $product->get_review_count(),

--- a/plugin/woo4etch/woo4etch.php
+++ b/plugin/woo4etch/woo4etch.php
@@ -2157,7 +2157,7 @@ final class Woo4Etch {
      *   stock_label                — localized availability text (may be empty for
      *                                in-stock products, per Woo inventory settings)
      *   stock_quantity (int|''), is_in_stock (bool)
-     *   is_purchasable, is_featured (bool)
+     *   is_purchasable, is_featured, sold_individually (bool)
      *   rating (float), rating_count, review_count (int)
      *   add_to_cart_url, add_to_cart_text
      *   weight, dimensions         — formatted; empty when not set
@@ -2227,6 +2227,7 @@ final class Woo4Etch {
             'is_in_stock'      => $product->is_in_stock(),
             'is_purchasable'   => $product->is_purchasable(),
             'is_featured'      => $product->is_featured(),
+            'sold_individually' => $product->is_sold_individually(),
             'rating'           => (float) $product->get_average_rating(),
             'rating_count'     => (int) $product->get_rating_count(),
             'review_count'     => (int) $product->get_review_count(),


### PR DESCRIPTION
Adds `is_sold_individually` to the `{this.*}` product data exposed to Etch, alongside the other boolean conditionals:

`'is_sold_individually' => $product->is_sold_individually(),`

Templates have no way to react to WooCommerce's "sold individually" flag. The most common need: a sold-individually product — one-per-order items like original artwork — shouldn't offer a quantity picker, but the hand-built simple-product form in the single-product layout renders one unconditionally, and there's no context key to wrap it with:

```
{#if !this.is_sold_individually}
  <input class="w4e-product__qty" type="number" name="quantity" value="1" min="1" step="1">
{/if}
```

The `[woo_if]` shortcode already supports `sold_individually`, so the concept is half-exposed — this brings the Etch context to parity. Without it, sites have to re-add the key themselves via the `etch/dynamic_data/post` filter.

The key is named `is_sold_individually` (rather than the shortcode's `sold_individually`) to match the naming convention of its sibling booleans in the context array: `is_purchasable`, `is_featured`, `is_in_stock`, `is_on_sale`, `is_simple`.