### PR TITLE
[woo_product_attributes] + cart_item_payload filter + production findings (docs & snippets)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); ver
 
 Releases are published as [GitHub Releases](https://github.com/tobiashaas/woo4etch/releases); regular plugin installs self-update from there. The same changelog ships inside the plugin in `plugin/woo4etch/readme.txt` — keep both in sync.
 
+## [Unreleased]
+
+Findings from a production build (Caracciolo Olivenöl staging — Etch 1.6.2, WooCommerce block theme, Germanized, Mollie).
+
+### Added
+
+- **`[woo_product_attributes]`** — the "Additional information" attributes table (visible attributes plus weight/dimensions) as a shortcode; empty output when the product has no data. Needed because `woocommerce_product_additional_information` expects the product as a `do_action` **argument**, which neither `[do_action]` nor the `data-w4e-hook` island passes — the hooked `wc_display_product_attributes()` would receive `null`.
+- **`woo4etch/cart_item_payload` filter** — adjust each cart-item payload before it reaches `{options.cart_items}` / `{woo.cart.items}`. Primary use case: WooCommerce Germanized injects raw `gzd-*` rows (delivery time, item description) via `woocommerce_get_item_data` at priority ≥ 1000, which `{item.meta}` otherwise dumps verbatim into custom cart layouts.
+
+### Docs
+
+- **Archive context corrected** (10, 03): on product archives in Etch 1.6.x, `{this.title}` resolves to the **first product**, not the archive title, and `{taxonomy.name}` yields the taxonomy slug (`product_cat`), not the term. `{archive.title}` is the key that works for both term archives and the shop page. Search views expose **no** query keyword ( `{search.query}`/`{this.query}` render empty) — use a static heading.
+- **Gallery caveat** (01): with Woo styles disabled, give slide images an `aspect-ratio` guard — FlexSlider measures the viewport at init, and images that haven't loaded yet collapse it to 0 (the layout degrades to a bare thumbnail grid; also a CLS win).
+- **Copy/paste layouts** (etch-copy): builder-assigned classes ride as style-record references — when those records are lost, the next `saveAsync` silently strips the classes from the blocks. Re-apply critical classes as explicit `class` attributes.
+- **New snippets** (13): product option checkbox (pre-assembly & similar) via four hooks incl. the `$_REQUEST` add-to-cart-URL pitfall, and taming Germanized's `gzd-*` rows in classic cart renders (priority `PHP_INT_MAX` + REST guard so the checkout block keeps its mandatory delivery-time display).
+
 ## [1.5.0-beta.6] — 2026-06-13
 
 Pre-release — not offered to installed sites via the auto-updater; install manually to test.

--- a/plugin/woo4etch/readme.txt
+++ b/plugin/woo4etch/readme.txt
@@ -34,6 +34,7 @@ Product data:
 * `[woo_weight]` / `[woo_dimensions]` — formatted weight / dimensions
 * `[woo_meta key="..." default="..."]` — any product meta field
 * `[woo_attribute name="pa_color" default="..."]` — product attribute by taxonomy
+* `[woo_product_attributes]` — full attributes table (visible attributes + weight/dimensions), empty when the product has no data
 * `[woo_categories]` / `[woo_tags]` — linked category / tag list
 * `[woo_short_description]` / `[woo_description]` — product copy (filtered HTML)
 
@@ -114,6 +115,10 @@ WooCommerce must be installed and active.
 In the admin, open **Etch → Woo4Etch** for a table of all shortcodes with copy buttons (or **WooCommerce → Woo4Etch** when Etch is not active).
 
 == Changelog ==
+
+= Unreleased =
+* New: `[woo_product_attributes]` — the "Additional information" attributes table (visible attributes + weight/dimensions) as a shortcode. Needed because the woocommerce_product_additional_information hook expects the product as a do_action argument, which the hook island cannot pass.
+* New: `woo4etch/cart_item_payload` filter — adjust each cart-item payload (e.g. strip Germanized's gzd-* rows from `meta`) before it reaches `{options.cart_items}`.
 
 = 1.5.0-beta.6 =
 * Minimum PHP is now 8.1 (Etch itself requires it; 7.4/8.0 support was dead weight). No code changed — the plugin already ran on 8.1+.

--- a/plugin/woo4etch/woo4etch.php
+++ b/plugin/woo4etch/woo4etch.php
@@ -317,6 +317,13 @@ final class Woo4Etch {
                 'description' => __('Product attribute by taxonomy slug (e.g. pa_color).', 'woo4etch'),
                 'example'     => '[woo_attribute name="pa_color"]',
             ],
+            'woo_product_attributes' => [
+                'method'      => 'shortcode_product_attributes',
+                'category'    => __('Product data', 'woo4etch'),
+                'attributes'  => 'id',
+                'description' => __('Full attributes table (visible attributes plus weight/dimensions) — the "Additional information" tab as a table, empty when the product has no data.', 'woo4etch'),
+                'example'     => '[woo_product_attributes]',
+            ],
             'woo_categories' => [
                 'method'      => 'shortcode_categories',
                 'category'    => __('Product data', 'woo4etch'),
@@ -1182,6 +1189,28 @@ final class Woo4Etch {
         }
         $value = $product->get_attribute(sanitize_text_field($atts['name']));
         return $value === '' ? esc_html($atts['default']) : esc_html($value);
+    }
+
+    /**
+     * Full attributes table — WooCommerce's "Additional information" tab as a
+     * plain table (visible attributes plus weight/dimensions when enabled).
+     * Returns an empty string when the product has nothing to show, so a
+     * surrounding heading can be shipped conditionally by the layout.
+     *
+     * Why a shortcode and not the woocommerce_product_additional_information
+     * hook via [do_action]/data-w4e-hook: that hook expects the product as a
+     * do_action ARGUMENT, which the hook island does not pass — the callbacks
+     * would receive null. wc_display_product_attributes() needs the object.
+     */
+    public static function shortcode_product_attributes($atts) {
+        $atts = shortcode_atts(['id' => 0], $atts, 'woo_product_attributes');
+        $product = self::resolve_product($atts);
+        if (!$product || !function_exists('wc_display_product_attributes')) {
+            return '';
+        }
+        ob_start();
+        wc_display_product_attributes($product);
+        return trim(ob_get_clean());
     }
 
     /* ============================================================
@@ -2341,12 +2370,15 @@ final class Woo4Etch {
             $image = wc_placeholder_img_src($size);
         }
 
-        return [
+        $payload = [
             'key'        => $key,
             'id'         => $product->get_id(),
             'name'       => $product->get_name(),
             'sku'        => $product->get_sku(),
             // Variation / add-on attributes as a flat string, e.g. "Color: Blue, Size: M".
+            // Note: third parties can inject noisy rows via woocommerce_get_item_data
+            // (Germanized adds gzd-* entries) — filter the payload below, or unhook
+            // their get_item_data filter for classic renders (see 13-useful-snippets.md).
             'meta'       => self::plain(wc_get_formatted_cart_item_data($cart_item, true)),
             'quantity'   => $cart_item['quantity'],
             'price'      => self::plain(WC()->cart->get_product_price($product)),
@@ -2356,6 +2388,16 @@ final class Woo4Etch {
             'remove_url' => wc_get_cart_remove_url($key),
             'on_sale'    => $product->is_on_sale(),
         ];
+
+        /**
+         * Adjust one cart-item payload before it reaches the dynamic-data bridge
+         * ({options.cart_items} / {woo.cart.items}).
+         *
+         * @param array      $payload   The item payload (key, id, name, meta, …).
+         * @param array      $cart_item Raw WooCommerce cart item.
+         * @param WC_Product $product   Resolved product object.
+         */
+        return apply_filters('woo4etch/cart_item_payload', $payload, $cart_item, $product);
     }
 
     /**

--- a/templates/01-single-product-simple.md
+++ b/templates/01-single-product-simple.md
@@ -221,6 +221,12 @@ What the scripts key off — don't drop these:
 
 Caveats:
 
+- **Give slide images an `aspect-ratio` guard** — FlexSlider measures the viewport height at init, and images that haven't finished loading measure 0: the main slide collapses and the gallery degrades to a bare thumbnail grid (races on slow connections and in headless tests; also a CLS win). One rule fixes it:
+
+  ```css
+  .woocommerce-product-gallery__image img { inline-size: 100%; aspect-ratio: 1 / 1; object-fit: contain; display: block; }
+  ```
+
 - In the hand-written variant `data-thumb="{image.url}"` points at the full-size file — fine for small galleries, but the thumbnail strip then downloads full images. `[woo_gallery mode="woo"]` uses the registered `woocommerce_gallery_thumbnail` size instead; prefer it for image-heavy products.
 - Slider and zoom-trigger styling (`.flex-control-thumbs`, the 🔍 button) lives in WooCommerce's stylesheets. If you checked **Disable WooCommerce default styles**, add a minimal replacement yourself:
 

--- a/templates/03-product-archive.md
+++ b/templates/03-product-archive.md
@@ -11,7 +11,7 @@ Loop with product cards for `/shop`, categories, and tag pages. AJAX add-to-cart
 
 ## Preparation
 
-> **Etch context:** this is an **Archive template** in the Etch Template Hub. `{this.*}` refers to the archive context (category/tag term, or the shop page on `/shop`); each product card uses `{item.*}` inside `{#loop mainQuery as item}`. Do not use `{this.title}` inside the loop — that stays the archive title, not the product. See [`10-etch-context-and-templates.md`](./10-etch-context-and-templates.md).
+> **Etch context:** this is an **Archive template** in the Etch Template Hub. The archive heading is `{archive.title}` (term name on category views, "Shop" on `/shop`) — **not** `{this.title}`, which resolves to the first product of the query on Etch 1.6.x, and not `{taxonomy.name}`, which yields the taxonomy slug. Each product card uses `{item.*}` inside `{#loop mainQuery as item}`. See [`10-etch-context-and-templates.md`](./10-etch-context-and-templates.md).
 
 WooCommerce must be declared in the theme (see [`00-README.md`](./00-README.md)).
 
@@ -31,9 +31,12 @@ That loads the `wc-add-to-cart` script and fragments for mini-cart updates.
 
   <header class="archive-header">
     <h1 class="woocommerce-products-header__title page-title">
-      {this.title}
+      {archive.title}
     </h1>
-    <div class="term-description">{this.description}</div>
+    <!-- {term.name} is verified on term views; {term.description} follows the
+         same context (verify on your build — on /shop there is no term, so
+         ship the description div conditionally or drop it) -->
+    <div class="term-description">{term.description}</div>
   </header>
 
   <!-- Hook: woocommerce_before_shop_loop -->

--- a/templates/10-etch-context-and-templates.md
+++ b/templates/10-etch-context-and-templates.md
@@ -80,7 +80,11 @@ Etch's recommended template types:
 | **404** | Anything that doesn't match | No `this.*` |
 | **Index (catch-all)** | Fallback when no specific template matches | Depends on the request |
 
-Inside a Single template, `{this.title}` gives the product title. Inside an Archive template, `{this.title}` gives the archive title (category/tag term, or the shop page on `/shop`) and you loop products with `{#loop mainQuery as item}` — never `{this.title}` for cards inside that loop.
+Inside a Single template, `{this.title}` gives the product title. Inside an Archive template, loop products with `{#loop mainQuery as item}` — never `{this.title}` for cards inside that loop.
+
+> **Archive heading — use `{archive.title}`, not `{this.title}` (verified on Etch 1.6.2).** On product archives `{this.title}` resolves to the **first product of the query**, not the archive title, and `{taxonomy.name}` yields the taxonomy slug (`product_cat`), not the term name. `{archive.title}` returns the term name on category/tag views **and** "Shop" on `/shop` — the one key that works for both. `{term.name}` works on term views only.
+>
+> **Search views expose no query keyword.** `{search.query}`, `{this.query}`, `{search.term}` all render empty on `?s=…` — use a static heading ("Search results") on the Search template. When unsure which key resolves, render a throwaway text block with all candidates (`K1[{a}] K2[{b}] …`) and read the frontend — don't guess.
 
 ### Pages (static layout, dynamic data injected)
 

--- a/templates/13-useful-snippets.md
+++ b/templates/13-useful-snippets.md
@@ -356,6 +356,76 @@ add_action('woocommerce_order_status_processing', function ($order_id) {
 });
 ```
 
+## Product option checkbox (pre-assembly, gift wrap, engraving note, …)
+
+A yes/no product option that travels from the product page through the cart into
+the order (order emails, admin, packing slip) — without the Product Add-ons
+plugin. Four hooks; verified end-to-end on a live build (variable products,
+Germanized, Mollie).
+
+```php
+// 1) Checkbox before the add-to-cart button.
+//    Fires inside Woo's own variable-product form; hand-written simple-product
+//    forms need a [do_action hook="woocommerce_before_add_to_cart_button"]
+//    island at that spot (see 01/15).
+add_action('woocommerce_before_add_to_cart_button', function () {
+    global $product;
+    if (!$product instanceof WC_Product) return;
+    // Optional gate, e.g. only a category:
+    // if (!has_term('containers', 'product_cat', $product->get_id())) return;
+    $checked = isset($_POST['my_option']) ? 'checked' : '';
+    echo '<label class="my-option"><input type="checkbox" name="my_option" value="1" ' . $checked . '> '
+        . esc_html__('Pre-assemble before shipping', 'textdomain') . '</label>';
+});
+
+// 2) Into the cart item. Read $_REQUEST, not $_POST — the ?add-to-cart=…
+//    URL route (see "Add-to-cart URLs" above) arrives as GET and would
+//    silently drop the option otherwise.
+add_filter('woocommerce_add_cart_item_data', function (array $data, int $product_id): array {
+    if (!empty($_REQUEST['my_option'])) {
+        $data['my_option'] = true;
+    }
+    return $data;
+}, 10, 2);
+
+// 3) Display on the cart/checkout line item.
+add_filter('woocommerce_get_item_data', function (array $item_data, array $cart_item): array {
+    if (!empty($cart_item['my_option'])) {
+        $item_data[] = ['key' => __('Pre-assembly', 'textdomain'), 'value' => __('Yes', 'textdomain')];
+    }
+    return $item_data;
+}, 10, 2);
+
+// 4) Persist on the order line item (emails, admin, packing slip).
+add_action('woocommerce_checkout_create_order_line_item', function ($item, $key, $values) {
+    if (!empty($values['my_option'])) {
+        $item->add_meta_data(__('Pre-assembly', 'textdomain'), __('Yes', 'textdomain'), true);
+    }
+}, 10, 3);
+```
+
+## Tame Germanized's gzd-* rows in custom cart layouts
+
+WooCommerce Germanized injects raw rows (`gzd-delivery_time`, `gzd-item_desc`, …)
+via `woocommerce_get_item_data` **at priority ≥ 1000** — a custom cart layout
+rendering `{item.meta}` dumps them verbatim. Strip them for classic renders only;
+the checkout **block** (Store API) must keep them — the delivery time shown there
+is a mandatory disclosure in DE shops:
+
+```php
+add_filter('woocommerce_get_item_data', function (array $item_data): array {
+    if (defined('REST_REQUEST') && REST_REQUEST) {
+        return $item_data; // Store API / checkout block: untouched
+    }
+    return array_values(array_filter($item_data, function ($d) {
+        return strpos((string) ($d['key'] ?? $d['name'] ?? ''), 'gzd-') !== 0;
+    }));
+}, PHP_INT_MAX); // must run AFTER Germanized — an ordinary 999 is too early
+```
+
+Alternative without PHP: reshape the payload via the `woo4etch/cart_item_payload`
+filter (see [`15-woo4etch-plugin.md`](./15-woo4etch-plugin.md)).
+
 ## Sources
 
 - Business Bloomer — [Custom Add to Cart URLs](https://www.businessbloomer.com/woocommerce-custom-add-cart-urls-ultimate-guide/)

--- a/templates/15-woo4etch-plugin.md
+++ b/templates/15-woo4etch-plugin.md
@@ -215,6 +215,10 @@ add_filter('woo4etch/allow_do_action', function ($allowed, $hook) {
 [woo_weight default="—"]      [woo_dimensions default="—"]
 [woo_meta key="_my_field" default="—"]
 [woo_attribute name="pa_color"]
+[woo_product_attributes]      → full attributes table ("Additional information":
+                                visible attributes + weight/dimensions; empty
+                                output when the product has no data — ship the
+                                surrounding heading conditionally)
 [woo_categories sep=", "]     [woo_tags sep=", "]
 [woo_short_description]       [woo_description]
 ```

--- a/templates/etch-copy/README.md
+++ b/templates/etch-copy/README.md
@@ -60,3 +60,12 @@ shortcode placeholder in the builder). See [`../15-woo4etch-plugin.md`](../15-wo
 > The class CSS embedded in the snippet uses literal colours (it mirrors the demo's
 > `tests/manual/demo-mu/demo.css`). Tweak the classes in Etch's CSS panel to match
 > your design — or wire them to your Automatic.css / design-token variables.
+
+> **Class-stripping pitfall:** the pasted blocks carry their classes as
+> **style-record references**, not as plain `class` attributes. If those style
+> records ever get lost (deleted in a cleanup, or a stale builder session
+> reverts them), the classes still render — until the **next save of that
+> document silently strips them** and the layout falls apart while its CSS is
+> still present. If you restyle the layout outside Etch's style panel (e.g.
+> moving the CSS into a global stylesheet), re-apply the critical classes as
+> explicit `class` attributes on the blocks first.

--- a/templates/functions-snippets.md
+++ b/templates/functions-snippets.md
@@ -791,6 +791,21 @@ $url = wp_nonce_url(
 
 ## Useful smaller helpers
 
+### Product option checkbox (pre-assembly, gift wrap, …) → order meta
+
+Full walkthrough incl. the `$_REQUEST` pitfall in [`13-useful-snippets.md`](./13-useful-snippets.md#product-option-checkbox-pre-assembly-gift-wrap-engraving-note-):
+checkbox via `woocommerce_before_add_to_cart_button`, cart via
+`woocommerce_add_cart_item_data` (read `$_REQUEST`, not `$_POST` — the
+`?add-to-cart=` URL route is GET), display via `woocommerce_get_item_data`,
+order via `woocommerce_checkout_create_order_line_item`.
+
+### Tame Germanized's gzd-* rows in custom cart layouts
+
+Germanized adds raw `gzd-*` entries through `woocommerce_get_item_data` at
+priority ≥ 1000; `{item.meta}` dumps them verbatim. Filter at `PHP_INT_MAX`
+with a `REST_REQUEST` guard (checkout block keeps its mandatory delivery-time
+display) — snippet in [`13-useful-snippets.md`](./13-useful-snippets.md#tame-germanizeds-gzd--rows-in-custom-cart-layouts).
+
 ### Stop WooCommerce from loading scripts on non-Woo pages
 
 ```php


### PR DESCRIPTION
## Was drin ist

Findings aus einem echten Produktions-Build (Caracciolo Olivenöl Staging — Etch 1.6.2, WooCommerce Block-Theme, Germanized, Mollie), wie in CLAUDE.md vorgesehen dokumentiert und upstream gefixt.

### Plugin

- **Neuer Shortcode `[woo_product_attributes]`** — die „Zusätzliche Informationen"-Attributtabelle (sichtbare Attribute + Gewicht/Maße), leer wenn das Produkt keine Daten hat. Hintergrund: `woocommerce_product_additional_information` erwartet das Produkt als **do_action-Argument**, das weder `[do_action]` noch das `data-w4e-hook`-Island übergibt — `wc_display_product_attributes()` bekäme `null`.
- **Neuer Filter `woo4etch/cart_item_payload`** — Payload je Cart-Item vor der Bridge anpassbar (Hauptfall: Germanized kippt rohe `gzd-*`-Zeilen über `woocommerce_get_item_data` @ Prio >=1000 in `{item.meta}`).

### Docs-Korrekturen (live verifiziert)

- **Archiv-Kontext (10, 03):** `{archive.title}` ist der Key, der auf Term-Archiven UND `/shop` funktioniert. `{this.title}` löst auf Produkt-Archiven zum **ersten Produkt** auf, `{taxonomy.name}` zum Taxonomie-Slug (`product_cat`). Such-Views exponieren **kein** Query-Keyword → statische Überschrift. Template-03-Markup auf `{archive.title}` umgestellt.
- **Galerie-Caveat (01):** FlexSlider misst den Viewport beim Init — noch nicht geladene Bilder = Höhe 0, die Galerie degradiert zum nackten Thumbnail-Raster. `aspect-ratio`-Guard-CSS ergänzt (nebenbei CLS-Gewinn).
- **etch-copy README:** Klassen der Paste-Layouts hängen an Style-Record-Refs — gehen die Records verloren, strippt der nächste Save die Klassen still. Warnung + Empfehlung (kritische Klassen als explizite `class`-Attribute).

### Neue Snippets (13 + functions-snippets)

- **Produkt-Options-Checkbox** (Vormontage/Geschenkverpackung/...) → Cart-Item-Data → Order-Meta, inkl. der `$_REQUEST`-Falle (der `?add-to-cart=`-URL-Weg kommt als GET).
- **Germanized `gzd-*`-Zeilen zähmen**: Filter mit `PHP_INT_MAX` + `REST_REQUEST`-Guard (Checkout-Block behält die Lieferzeit-Pflichtanzeige).

## Verifikation

Alles auf dem Staging-Build end-to-end getestet: Attributtabelle rendert (11 Zeilen auf attributreichem Produkt, still bei leeren), Options-Checkbox bis in die Bestellung (#1097, Positions-Meta), gzd-Filter im klassischen Cart aktiv bei unangetastetem Checkout-Block. Kein Versions-Bump (per CLAUDE.md); Changelog unter [Unreleased], readme.txt synchron.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0175tvcSJ8nU4dRTrPXuYFsx